### PR TITLE
Updated for seneca 0.5.20, use REQ/REP rather than PUSH/PULL

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
   "devDependencies": {
     "gex": "0.1.x",
     "chai": "1.8.x",
-    "mocha": "1.17.x"
+    "mocha": "1.17.x",
+    "seneca": "~0.5.20",
+    "seneca-transport-test": "~0.1.2"
   },
   "files": [
     "README.md",

--- a/test/zmq-transport.test.js
+++ b/test/zmq-transport.test.js
@@ -1,0 +1,18 @@
+/* Copyright (c) 2014 Richard Rodger */
+"use strict";
+
+// mocha zmq-transport.test.js
+
+var test = require('seneca-transport-test')
+
+
+describe('zmq-transport', function() {
+
+    it('happy-zmq', function( fin ) {
+        test.foo_test( 'zmq-transport', require, fin, 'zmq', 10201 )
+    })
+    it('happy-pin', function( fin ) {
+        test.foo_pintest( 'zmq-transport', require, fin, 'zmq', 10201 )
+    })
+
+})

--- a/zmq-transport.js
+++ b/zmq-transport.js
@@ -12,8 +12,6 @@ var connect     = require('connect')
 var request     = require('request')
 var zmq         = require('zmq')
 
-var nid = require('nid')
-
 
 module.exports = function( options ) {
   var seneca = this
@@ -44,83 +42,12 @@ module.exports = function( options ) {
   seneca.add({role:'transport',hook:'listen',type:'pubsub'}, hook_listen_zmq)
   seneca.add({role:'transport',hook:'client',type:'pubsub'}, hook_client_zmq)
  
-  function parseConfig( args ) {
-    var out = {}
-
-    var config = args.config || args
-    var base = options.direct
-
-    if( _.isArray( config ) ) {
-      var arglen = config.length
-
-      if( 0 === arglen ) {
-        out.port = base.port
-        out.host = base.host
-        out.path = base.path
-      }
-      else if( 1 === arglen ) {
-        if( _.isObject( config[0] ) ) {
-          out = config[0]
-        }
-        else {
-          out.port = parseInt(config[0])
-          out.host = base.host
-          out.path = base.path
-        }
-      }
-      else if( 2 === arglen ) {
-        out.port = parseInt(config[0])
-        out.host = config[1]
-        out.path = base.path
-      }
-      else if( 3 === arglen ) {
-        out.port = parseInt(config[0])
-        out.host = config[1]
-        out.path = config[2]
-      }
-
-    }
-    else out = config;
-
-    out.type = null == out.type ? base.type : out.type
-
-    if( 'direct' == out.type ) {
-      out.port = null == out.port ? base.port : out.port
-      out.host = null == out.host ? base.host : out.host
-      out.path = null == out.path ? base.path : out.path
-    }
-
-    return out
-  }
-
-
-  // only support first level
-  function handle_entity( raw ) {
-    raw = _.isObject( raw ) ? raw : {}
-
-    if( raw.entity$ ) {
-      return seneca.make$( raw )
-    }
-    else {
-      _.each( raw, function(v,k){
-        if( _.isObject(v) && v.entity$ ) {
-          raw[k] = seneca.make$( v )
-        }
-      })
-      return raw
-    }
-  }
-
-
-
   var mark = '~'
-
 
 
   function hook_listen_zmq( args, done ) {
     var seneca = this
     var type           = args.type
-
     var listen_options = seneca.util.clean(_.extend({},options[type],args))
 
     var listenpoint = listen_options.pubsub.listenpoint
@@ -132,48 +59,36 @@ module.exports = function( options ) {
     zmq_in.identity  = 'listen-sub-'+process.id
     zmq_out.identity = 'listen-pub-'+process.id
 
-    zmq_out.bind(clientpoint)
-
+    zmq_out.bind(clientpoint, function(err){
+        if( err ) return done(err);
+      })
 
     zmq_in.connect(listenpoint, function(err){
       if( err ) return done(err);
     })
 
-
-
-    if( args.pin ) {
-      var pins = _.isArray(args.pin) ? args.pin : [args.pin]
-      _.each( seneca.findpins( pins ), function(pin){
-        var pinstr = options.msgprefix+util.inspect(pin)
-        //zmq_in.subscribe(pinstr)
-      })
-    }
-
-    //zmq_in.subscribe(options.msgprefix+'all')
-
-
     zmq_in.on('message',function(msgstr){
       msgstr = ''+msgstr
       var index = msgstr.indexOf(mark)
       var channel = msgstr.substring(0,index)
-      var data = JSON.parse(msgstr.substring(index+1))
+      var data = tu.parseJSON(seneca, 'listen-'+type, msgstr.substring(index+1))
 
-      if( 'act' == data.kind ) {
-        seneca.act(data.act,function(err,res){
-          var outmsg = {
-            kind:'res',
-            id:data.id,
-            err:err?err.message:null,
-            res:res
-          }
-          var outstr = JSON.stringify(outmsg)
-          zmq_out.send(channel+mark+outstr)
-        })
-      }
+      tu.handle_request( seneca, data, listen_options, function(out){
+        if( null == out ) return;
+        var outstr = tu.stringifyJSON( seneca, 'listen-'+type, out )
+        zmq_out.send(channel+mark+outstr)
+      })
     })
 
+    seneca.add('role:seneca,cmd:close',function( close_args, done ) {
+      var closer = this
 
-    seneca.log.info('listen', 'pubsub', 'zmq', listenpoint, clientpoint, seneca.toString())
+      zmq_in.close()
+      zmq_out.close()
+      closer.prior(close_args,done)
+    })
+
+    seneca.log.info('listen', 'open', listen_options, seneca)
 
     done()
   }
@@ -181,7 +96,6 @@ module.exports = function( options ) {
 
 
   function hook_client_zmq( args, clientdone ) {
-
     var seneca         = this
     var type           = args.type
     var client_options = seneca.util.clean(_.extend({},options[type],args))
@@ -189,14 +103,11 @@ module.exports = function( options ) {
     tu.make_client( make_send, client_options, clientdone )
 
     function make_send( spec, topic, send_done ) {
-
       var listenpoint = client_options.pubsub.listenpoint
       var clientpoint = client_options.pubsub.clientpoint
  
       var zmq_in  = zmq.socket('pull')
       var zmq_out = zmq.socket('push')
-
-      var callmap = {}
 
       zmq_in.identity  = 'client-sub-'+process.id
       zmq_out.identity = 'client-pub-'+process.id
@@ -209,29 +120,20 @@ module.exports = function( options ) {
         if( err ) return send_done(err);
       })
 
-
       zmq_in.on('message',function(msgstr){
         msgstr = ''+msgstr
-
         var index = msgstr.indexOf(mark)
         var channel = msgstr.substring(0,index)
-        var data = JSON.parse(msgstr.substring(index+1))
+        var input = tu.parseJSON(seneca,'client-'+type,msgstr.substring(index+1))
 
-        if( 'res' == data.kind ) {
-          var call = callmap[data.id]
-          if( call ) {
-            delete callmap[data.id]
-
-            call.done( data.err ? new Error(data.err) : null, data.res )
-          }
-        }
+        tu.handle_response( seneca, input, client_options )
       })
 
-      var client = function( args, done ) {
+      seneca.log.debug('client', 'subscribe', topic+'_res', client_options, seneca)
+
+      send_done(null, function( args, done ) {
         var outmsg = tu.prepare_request( this, args, done )
         var outstr = tu.stringifyJSON( seneca, 'client-zmq', outmsg )
-
-        callmap[outmsg.id] = {done:done}
 
         var actmeta = seneca.findact(args)
         if( actmeta ) {
@@ -241,19 +143,6 @@ module.exports = function( options ) {
         else {
           zmq_out.send(options.msgprefix+'all'+mark+outstr)
         }
-      }
-
-      if( args.pin ) {
-        var pins = _.isArray(args.pin) ? args.pin : [args.pin]
-        _.each( seneca.findpins( pins ), function(pin){
-          var pinstr = options.msgprefix+util.inspect(pin)
-          seneca.add(pin,client)
-          //zmq_in.subscribe(pinstr)
-        })
-      }
-
-      send_done( null, function( args, done ) {
-        client.call(this,args,done);
       })
 
       seneca.add('role:seneca,cmd:close',function( close_args, done ) {
@@ -263,11 +152,6 @@ module.exports = function( options ) {
         zmq_out.close();
         closer.prior(close_args,done)
       })
-
-
-      //zmq_in.subscribe(options.msgprefix+'all')
-
-      seneca.log.info('client', 'pubsub', 'zmq', listenpoint, clientpoint, seneca.toString())
 
     }
 


### PR DESCRIPTION
Changes:
- Use latest seneca-transport
- Change zeromq messaging pattern to REQ/REP (i.e. client/server) rather than PUSH/PULL.
  - Previous implementation was responding to client by client opening a pull socket and the server pushing to it.
  - Pipelining should be provided by seneca - so REQ/REP more suitable than PUSH/PULL
- Use seneca-transport-test standard tests
